### PR TITLE
Remove unused DayOfWeekEntity import

### DIFF
--- a/src/Application/Infrastructure/Data/Context/ApplicationDbContext.cs
+++ b/src/Application/Infrastructure/Data/Context/ApplicationDbContext.cs
@@ -1,6 +1,5 @@
 using Microsoft.EntityFrameworkCore;
 using Application.Domain.Entities;
-using DayOfWeekEntity = Application.Domain.Entities.DayOfWeekEntity;
 
 namespace Application.Infrastructure.Data.Context;
 


### PR DESCRIPTION
The import statement for `DayOfWeekEntity` from
`Application.Domain.Entities` has been removed in the `ApplicationDbContext` class, indicating that it is no longer needed, possibly due to a refactor or removal of related functionality.